### PR TITLE
Update to 7.80.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,6 +9,7 @@ export CFLAGS="$CFLAGS $CPPFLAGS"
     --prefix=${PREFIX} \
     --host=${HOST} \
     --disable-ldap \
+    --disable-manual \
     --with-ca-bundle=${PREFIX}/ssl/cacert.pem \
     --with-ssl=${PREFIX} \
     --with-zlib=${PREFIX} \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,6 @@ outputs:
         - {{ pin_subpackage('libcurl', exact=True) }}
       run:
         - {{ pin_subpackage('libcurl', exact=True) }}
-        - zlib  # [osx or s390x]
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,24 +89,14 @@ outputs:
     files:
       - bin/curl               # [unix]
       - Library/bin/curl.exe*   # [win]
-    build:
-      # 2021/11/17: curl 7.80.0 has "ERROR (curl): run-exports library package [libssh2|krb5|zlib] in requirements/run".
-      # To avoid this was used ignore_run_exports
-      ignore_run_exports: 
-        - libssh2          # [linux or osx  or win]
-        - krb5             # [linux or osx or win]
-        - zlib             # [linux or win]
     requirements:
       build:
         - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libcurl', exact=True) }}
-        - zlib
-        - libssh2
-        - krb5
       run:
         - {{ pin_subpackage('libcurl', exact=True) }}
-        - libssh2
+
     test:
       commands:
         # curl help commands on Windows have non-zero status codes.  Need other test.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.78.0" %}
+{% set version = "7.80.0" %}
 
 package:
   name: curl_split_recipe
@@ -6,7 +6,7 @@ package:
 
 source:
   url: http://curl.haxx.se/download/curl-{{ version }}.tar.bz2
-  sha256: 98530b317dc95ccb324bbe4f834f07bb642fbc393b794ddf3434f246a71ea44a
+  sha256:  dd0d150e49cd950aff35e16b628edf04927f0289df42883750cf952bb858189c
 
 build:
   number: 0
@@ -89,6 +89,11 @@ outputs:
     files:
       - bin/curl               # [unix]
       - Library/bin/curl.exe*   # [win]
+    build:
+      ignore_run_exports: 
+        - libssh2          # [linux or osx  or win]
+        - krb5             # [linux or osx or win]
+        - zlib             # [linux or win]
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,7 @@ outputs:
         - {{ pin_subpackage('libcurl', exact=True) }}
       run:
         - {{ pin_subpackage('libcurl', exact=True) }}
-        - zlib  # [osx]
+        - zlib  # [osx or s390x]
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,6 +90,8 @@ outputs:
       - bin/curl               # [unix]
       - Library/bin/curl.exe*   # [win]
     build:
+      # 2021/11/17: curl 7.80.0 has "ERROR (curl): run-exports library package [libssh2|krb5|zlib] in requirements/run".
+      # To avoid this was used ignore_run_exports
       ignore_run_exports: 
         - libssh2          # [linux or osx  or win]
         - krb5             # [linux or osx or win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,6 +96,7 @@ outputs:
         - {{ pin_subpackage('libcurl', exact=True) }}
       run:
         - {{ pin_subpackage('libcurl', exact=True) }}
+        - zlib  # [osx]
 
     test:
       commands:


### PR DESCRIPTION
Update curl to 7.80.0.

This version fixes CVEs: 
CVE-2021-22947 | CVE-2021-22946 | CVE-2021-22945 

Version change: bump version number from 7.78.0 to 7.80.0
Bug Tracker: new open issues https://github.com/curl/curl/issues
Github releases:  https://github.com/curl/curl/releases
Upstream license:  License file:  https://github.com/curl/curl/blob/master/COPYING
Upstream Changelog: https://curl.se/changes.html

The package curl is mentioned inside the packages:
ca-certificates | clang-win-activation | cmake-binary |  gdal | git | h5py | htslib | libarchive | _libarchive_static_for_cph | libdap4 | libgit2 | libnetcdf | libssh2 | openblas | poppler | pycurl | ray-packages | tiledb |

Actions:
1. Add ignore_run_exports for the curl output

Result:
- all-succeeded