### PR TITLE
curl 7.82.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: http://curl.haxx.se/download/curl-{{ version }}.tar.bz2
+  url: https://curl.haxx.se/download/curl-{{ version }}.tar.bz2
   sha256: 46d9a0400a33408fd992770b04a44a7434b3036f2e8089ac28b57573d59d371f
 
 build:
@@ -106,7 +106,7 @@ outputs:
         - if not exist %LIBRARY_BIN%\curl.exe exit 1  # [win]
 
 about:
-  home: http://curl.haxx.se/
+  home: https://curl.haxx.se/
   license: curl
   license_family: MIT
   license_file: COPYING

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.80.0" %}
+{% set version = "7.82.0" %}
 
 package:
   name: curl_split_recipe
@@ -6,7 +6,7 @@ package:
 
 source:
   url: http://curl.haxx.se/download/curl-{{ version }}.tar.bz2
-  sha256:  dd0d150e49cd950aff35e16b628edf04927f0289df42883750cf952bb858189c
+  sha256: 46d9a0400a33408fd992770b04a44a7434b3036f2e8089ac28b57573d59d371f
 
 build:
   number: 0


### PR DESCRIPTION
Update curl to 7.82.0

Version change: bump version number from 7.80.0 to 7.82.0
Bug Tracker: new open issues https://github.com/curl/curl/issues
Github releases: https://github.com/curl/curl/releases
Upstream license: License file: https://github.com/curl/curl/blob/master/COPYING
Upstream Changelog: https://curl.se/changes.html

The package curl is mentioned inside the packages:
ca-certificates | clang-win-activation | cmake-binary | gdal | git | h5py | htslib | libarchive | _libarchive_static_for_cph | libdap4 | libgit2 | libnetcdf | libssh2 | openblas | poppler | pycurl | ray-packages | tiledb |

Actions:

1. Fix source/url and home url with HTTPS

Result:

all-succeeded