### PR TITLE
Update curl 7.82.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,13 +9,13 @@ if %ARCH% == 32 (
 REM This is implicitly using WinSSL.  See Makefile.vc for more info.
 nmake /f Makefile.vc MODE=dll VC=%VS_MAJOR:"=% WITH_DEVEL=%LIBRARY_PREFIX% ^
          WITH_ZLIB=dll WITH_SSH2=dll DEBUG=no ENABLE_IDN=no ENABLE_SSPI=yes ^
-         MACHINE=%ARCH_STRING%
+         MACHINE=%ARCH_STRING% ENABLE_UNICODE=yes
 if errorlevel 1 exit 1
 
 REM This is implicitly using WinSSL.  See Makefile.vc for more info.
 nmake /f Makefile.vc mode=static VC=%VS_MAJOR:"=% WITH_DEVEL=%LIBRARY_PREFIX% ^
          WITH_ZLIB=dll WITH_SSH2=dll DEBUG=no ENABLE_IDN=no ENABLE_SSPI=yes ^
-         MACHINE=%ARCH_STRING%
+         MACHINE=%ARCH_STRING% ENABLE_UNICODE=yes
 if errorlevel 1 exit 1
 
 REM install static library

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 0
-  # trigger 1
 
 requirements:
   build:


### PR DESCRIPTION
Update curl to 7.82.0

Version change: bump version number from 7.80.0 to 7.82.0
Bug Tracker: new open issues https://github.com/curl/curl/issues
Github releases: https://github.com/curl/curl/releases
Upstream license: License file: https://github.com/curl/curl/blob/master/COPYING
Upstream Changelog: https://curl.se/changes.html

Actions:
1. Fix source/url and home url with HTTPS
2. Enable unicode on win

Result:
all-succeeded