### PR TITLE
cur 7.83.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.82.0" %}
+{% set version = "7.83.0" %}
 
 package:
   name: curl_split_recipe
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://curl.haxx.se/download/curl-{{ version }}.tar.bz2
-  sha256: 46d9a0400a33408fd992770b04a44a7434b3036f2e8089ac28b57573d59d371f
+  sha256: 247c7ec7521c4258e65634e529270d214fe32969971cccb72845e7aa46831f96
 
 build:
   number: 0


### PR DESCRIPTION
Update curl to 7.83.0

Version change: bump version number from 7.82.0 to 7.83.0
Bug Tracker: new open issues https://github.com/curl/curl/issues
Github releases: https://github.com/curl/curl/releases
Upstream license: License file: https://github.com/curl/curl/blob/master/COPYING
Upstream Changelog: https://curl.se/changes.html

Actions:
Update version

Result:
all-succeeded

Concourse: https://concourse.build.corp.continuum.io/teams/main/pipelines/cbousseau_curl
Jira: https://anaconda.atlassian.net/browse/DSNC-4713