### PR TITLE
Updates curl to 7.86.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.85.0" %}
+{% set version = "7.86.0" %}
 
 package:
   name: curl_split_recipe
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://curl.se/download/curl-{{ version }}.tar.bz2
-  sha256: 21a7e83628ee96164ac2b36ff6bf99d467c7b0b621c1f7e317d8f0d96011539c
+  sha256: f5ca69db03eea17fa8705bdfb1a9f58d76a46c9010518109bb38f313137e0a28 
   patches:
     - sched_yield.patch
 


### PR DESCRIPTION
Upstream Repo: https://github.com/curl/curl
Changelog: https://curl.se/changes.html#7_86_0
Jira issue: https://anaconda.atlassian.net/browse/PKG-695

NOTE:
 - **v7.86.0** addresses CVEs: 
   - CVE-2022-42916 - https://curl.se/docs/CVE-2022-42916.html
   - CVE-2022-42915 - https://curl.se/docs/CVE-2022-42915.html
   - CVE-2022-35260 - https://curl.se/docs/CVE-2022-35260.html
   - CVE-2022-32221 - https://curl.se/docs/CVE-2022-32221.html