### PR TITLE
curl 7.87.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,7 +114,6 @@ about:
   license: curl
   license_family: MIT
   license_file: COPYING
-  license_url: https://github.com/curl/curl/blob/master/COPYING
   summary: tool and library for transferring data with URL syntax
 
   description: |
@@ -122,7 +121,6 @@ about:
     with URL syntax. It is used in command lines or scripts to transfer data.
   doc_url: https://curl.se/docs/
   dev_url: https://github.com/curl/curl
-  doc_source_url: https://github.com/curl/curl/tree/master/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.86.0" %}
+{% set version = "7.87.0" %}
 
 package:
   name: curl_split_recipe
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://curl.se/download/curl-{{ version }}.tar.bz2
-  sha256: f5ca69db03eea17fa8705bdfb1a9f58d76a46c9010518109bb38f313137e0a28 
+  sha256: 5d6e128761b7110946d1276aff6f0f266f2b726f5e619f7e0a057a474155f307 
   patches:
     - sched_yield.patch
 


### PR DESCRIPTION
# curl 7.87.0

jira: https://anaconda.atlassian.net/browse/PKG-1014
changelog: https://curl.se/changes.html

## Changes
- Update version and SHA
- Remove unnecessary urls from about section

## Notes
- This release has fixes for `CVE-2022-43551` see: https://curl.se/docs/security.html, and `CVE-2022-43552`, see: https://curl.se/docs/CVE-2022-43552.html