### PR TITLE
7.88.1: Ensure that the curl subpackage is built for both OpenSSL 1 and 3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 8224b45cce12abde039c12dc0711b7ea85b104b9ad534d6e4c5b4e188a61c907
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -89,10 +89,17 @@ outputs:
     files:
       - bin/curl                # [unix]
       - Library/bin/curl.exe*   # [win]
+    build:
+      ignore_run_exports:
+        # Ignoring the run export since we use openssl in the host section
+        # as a means to produce the right variants only. We don't need the dependency
+        # since it's already on libcurl.
+        - openssl
     requirements:
       build:
         - {{ compiler('c') }}
       host:
+        - openssl {{ openssl }}  # Only required to produce all openssl variants.
         - {{ pin_subpackage('libcurl', exact=True) }}
       run:
         - {{ pin_subpackage('libcurl', exact=True) }}


### PR DESCRIPTION
While building `pdal` with OpenSSL 1 (https://github.com/AnacondaRecipes/pdal-feedstock/pull/2), I was having a strange conflict. It turns out the conflict is caused by the fact that the `curl` package was only built with a single OpenSSL version, in this case 3.

This PR fixes that and ensures that the curl subpackage is built for both OpenSSL 1 and 3.

I will create another PR to do the same with curl 8.1.1.