### PR TITLE
Ensure that the curl subpackage is built for both OpenSSL 1 and 3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 51d2af72279913b5d4cab1fe1f38b944cf70904c88bee246b5bd575844e7035a
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -90,10 +90,17 @@ outputs:
     files:
       - bin/curl                # [unix]
       - Library/bin/curl.exe*   # [win]
+    build:
+      ignore_run_exports:
+        # Ignoring the run export since we use openssl in the host section
+        # as a means to produce the right variants only. We don't need the dependency
+        # since it's already on libcurl.
+        - openssl
     requirements:
       build:
         - {{ compiler('c') }}
       host:
+        - openssl {{ openssl }} # Only required to produce all openssl variants.
         - {{ pin_subpackage('libcurl', exact=True) }}
       run:
         - {{ pin_subpackage('libcurl', exact=True) }}


### PR DESCRIPTION
Same as https://github.com/AnacondaRecipes/curl-feedstock/pull/28 but for the latest version.

While building pdal with OpenSSL 1 (https://github.com/AnacondaRecipes/pdal-feedstock/pull/2), I was having a strange conflict. It turns out the conflict is caused by the fact that the curl package was only built with a single OpenSSL version, in this case 3.

This PR fixes that and ensures that the curl subpackage is built for both OpenSSL 1 and 3.