### PR TITLE
Only include openssl on unix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -40,7 +40,8 @@ outputs:
       run:
         - libnghttp2  >=1.57.0  # [unix]
         - libssh2     >=1.10.0
-        - openssl  # exact pin handled through openssl run_exports
+        # exact pin handled through openssl run_exports
+        - openssl  # [unix]
     build:
       run_exports:
         - {{ pin_subpackage('libcurl') }}
@@ -100,7 +101,8 @@ outputs:
       build:
         - {{ compiler('c') }}
       host:
-        - openssl {{ openssl }} # Only required to produce all openssl variants.
+        # Only required to produce all openssl variants.
+        - openssl {{ openssl }}  # [unix]
         - {{ pin_subpackage('libcurl', exact=True) }}
       run:
         - {{ pin_subpackage('libcurl', exact=True) }}


### PR DESCRIPTION
libcurl 8.4.0 still depends on openssl <1.1.2a on Windows.
```
libcurl 8.4.0 h86230a5_0
------------------------
file name   : libcurl-8.4.0-h86230a5_0.conda
name        : libcurl
version     : 8.4.0
build       : h86230a5_0
build number: 0
size        : 340 KB
license     : curl
subdir      : win-64
url         : https://repo.anaconda.com/pkgs/main/win-64/libcurl-8.4.0-h86230a5_0.conda
md5         : 023f310040d8f12635b59ce09f21370c
timestamp   : 2023-10-11 11:26:54 UTC
dependencies:
  - libssh2 >=1.10.0
  - libssh2 >=1.10.0,<2.0a0
  - openssl <1.1.2a
  - vc >=14.1,<15.0a0
  - vs2015_runtime >=14.16.27012,<15.0a0
  - zlib >=1.2.13,<1.3.0a0
```

This is caused by a combination of two things:

* https://github.com/AnacondaRecipes/curl-feedstock/blob/master/recipe/meta.yaml#L43
  OpenSSL isn’t needed on Windows. And we should only include it on unix.
* A hotfix (https://github.com/AnacondaRecipes/repodata-hotfixes/blob/b612e81d71970af6c0255d30453e6fb405e64e06/main.py#L940) was made when we started the transition from OpenSSL 1 to 3, which causes the upper bound.

This PR removes the openssl dependency on Windows. This fixes the issue.