### PR TITLE
Version 8.5.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.4.0" %}
+{% set version = "8.5.0" %}
 
 package:
   name: curl_split_recipe
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://curl.se/download/curl-{{ version }}.tar.bz2
-  sha256: e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6
+  sha256: ce4b6a6655431147624aaf582632a36fe1ade262d5fab385c60f78942dd8d87b
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
curl 8.5.0

**Destination channel:** defaults

### Links

- [PKG-3669](https://anaconda.atlassian.net/browse/PKG-3669)
- [Upstream repository](https://github.com/curl/curl/tree/curl-8_5_0)
- [Upstream changelog/diff](https://github.com/curl/curl/releases)

### Explanation of changes:

- Bump version to `8.5.0`
- Lower build number
- Add `abs.yaml` for 3.12 build


[PKG-3669]: https://anaconda.atlassian.net/browse/PKG-3669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ