### PR TITLE
Updated to 8.9.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -36,8 +36,8 @@ make -j${CPU_COUNT} ${VERBOSE_AT}
 # -j: parallelization
 # disable test 433, since it requires the glibc debug info
 # disable test 1173 and 1139 since --disable-manual is set
-# disable test 971 because of locale settings on osx
-make TFLAGS="-v -a -k -p -j$(CPU_COUNT) !433 !1173 !1139 !971" test-nonflaky
+# disable test 971, 1705, and 1706 because of locale settings on osx
+make TFLAGS="-v -a -k -p -j$(CPU_COUNT) !433 !1173 !1139 !971 !1705 !1706" test-nonflaky
 
 make install
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.7.1" %}
+{% set version = "8.9.1" %}
 
 package:
   name: curl_split_recipe
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://curl.se/download/curl-{{ version }}.tar.bz2
-  sha256: 05bbd2b698e9cfbab477c33aa5e99b4975501835a41b7ca6ca71de03d8849e76
+  sha256: b57285d9e18bf12a5f2309fc45244f6cf9cb14734e7454121099dd0a83d669a3
 
 build:
   number: 0


### PR DESCRIPTION
curl 8.9.1

**Destination channel:** defaults

### Links

- [PKG-5582](https://anaconda.atlassian.net/browse/PKG-5582) 
- [Upstream repository](https://github.com/curl/curl)
- [Upstream changelog/diff](https://curl.se/ch/8.9.1.html)

### Explanation of changes:

- Ignored new doc tests on OSX since they require a locale to be set


[PKG-5582]: https://anaconda.atlassian.net/browse/PKG-5582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ