### PR TITLE
curl 8.14.1: rebuild against libkrb5 1.21.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,23 +10,24 @@ source:
   sha256: 5760ed3c1a6aac68793fc502114f35c3e088e8cd5c084c2d044abdf646ee48fb
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - libtool        # [unix]
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
+    - libtool        # [unix]
     - make           # [linux]
     - cmake
-    - ninja-base  # [win]
+    - ninja-base     # [win]
     # perl is required to run the tests on UNIX.
     - perl           # [unix]
     - pkg-config     # [unix]
   host:
-    - krb5        {{ krb5 }}
+    - libkrb5     {{ krb5 }}
     - libnghttp2  {{ libnghttp2 }}  # [unix]
     - libssh2     {{ libssh2 }}
-    - openssl     {{ openssl }}  # [unix]
+    - openssl     {{ openssl }}     # [unix]
     - zlib        {{ zlib }}
     - zstd        {{ zstd }}
 
@@ -34,24 +35,25 @@ outputs:
   - name: libcurl
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
       host:
-        - krb5        {{ krb5 }}
+        - libkrb5     {{ krb5 }}
         - libnghttp2  {{ libnghttp2 }}  # [unix]
         - libssh2     {{ libssh2 }}
-        - openssl     {{ openssl }}  # [unix]
+        - openssl     {{ openssl }}     # [unix]
         - zlib        {{ zlib }}
         - zstd        {{ zstd }}
       run:
-        - libnghttp2  >=1.57.0  # [unix]
+        - libnghttp2  >=1.57.0          # [unix]
         - libssh2     >=1.10.0
         # exact pin handled through openssl run_exports
         - openssl  # [unix]
     build:
       run_exports:
         - {{ pin_subpackage('libcurl') }}
-      ignore_run_exports:  # [win]
-        - krb5             # [win]
+      ignore_run_exports:        # [win]
+        - libkrb5                # [win]
     files:
       - include/curl             # [unix]
       - lib/libcurl.so*          # [linux]
@@ -86,6 +88,7 @@ outputs:
         - openssl
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
       host:
         # Only required to produce all openssl variants.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,8 +52,8 @@ outputs:
     build:
       run_exports:
         - {{ pin_subpackage('libcurl') }}
-      ignore_run_exports:        # [win]
-        - libkrb5                # [win]
+      ignore_run_exports:
+        - libkrb5
     files:
       - include/curl             # [unix]
       - lib/libcurl.so*          # [linux]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8633](https://anaconda.atlassian.net/browse/PKG-8633) 
- [Upstream repository]()

### Explanation of changes:

- Rebuild against `libkrb5 1.21.3`
- `libkrb5` in `ignore_run_exports` on all platforms because of a `WARNING (libcurl): run-exports library package https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b/linux-64::libkrb5==1.21.3=h520c7b4_2 in requirements/run but it is not used (i.e. it is overdepending or perhaps statically linked? If that is what you want then add it to 'build/ignore_run_exports')`

### Notes:

-

[PKG-8633]: https://anaconda.atlassian.net/browse/PKG-8633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ