### PR TITLE
curl 8.14.1: Fix openssl pinning for Windows only

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 5760ed3c1a6aac68793fc502114f35c3e088e8cd5c084c2d044abdf646ee48fb
 
 build:
+  # trigger 1
   number: 1
 
 requirements:


### PR DESCRIPTION
Rebuild against https://github.com/AnacondaRecipes/krb5-feedstock/pull/13

Suppress the PR that hasn't been released https://github.com/AnacondaRecipes/curl-feedstock/pull/41

The build number is the same because it's not on the main channel yet