### PR TITLE
curl 8.19.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "curl" %}
-{% set version = "8.18.0" %}
+{% set version = "8.19.0" %}
 
 package:
   name: {{ name }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://{{ name }}.se/download/{{ name }}-{{ version }}.tar.bz2
-  sha256: ffd671a3dad424fb68e113a5b9894c5d1b5e13a88c6bdf0d4af6645123b31faf
+  sha256: eba3230c1b659211a7afa0fbf475978cbf99c412e4d72d9aa92d020c460742d4
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-13032](https://anaconda.atlassian.net/browse/PKG-13032)
- [Upstream repository](https://github.com/curl/curl/tree/curl-8_19_0)
- [Upstream changelog/diff](https://github.com/curl/curl/releases)

### Explanation of changes:

- Bump version number and add new sha256


[PKG-13032]: https://anaconda.atlassian.net/browse/PKG-13032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ