### PR TITLE
curl 8.20.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "curl" %}
-{% set version = "8.19.0" %}
+{% set version = "8.20.0" %}
 
 package:
   name: {{ name }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://{{ name }}.se/download/{{ name }}-{{ version }}.tar.bz2
-  sha256: eba3230c1b659211a7afa0fbf475978cbf99c412e4d72d9aa92d020c460742d4
+  sha256: 4be48e69cf467246cb97d369b85d78a08528f2b37cffef2418ee16e6a4eb596e
 
 build:
   number: 1


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-14359](https://anaconda.atlassian.net/browse/PKG-14359)
- [Upstream repository](https://github.com/curl/curl/tree/curl-8_20_0)
- [Upstream changelog/diff](https://curl.se/changes.html)

### Explanation of changes:

- Bump version and sha256


[PKG-14359]: https://anaconda.atlassian.net/browse/PKG-14359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ